### PR TITLE
Check for and update existing open reports

### DIFF
--- a/configsync/core.entity_view_display.node.report.default.yml
+++ b/configsync/core.entity_view_display.node.report.default.yml
@@ -134,8 +134,8 @@ content:
     weight: 14
     label: hidden
     settings:
-      format_type: medium
       timezone_override: ''
+      format_type: long
     third_party_settings: {  }
     type: datetime_default
     region: content

--- a/configsync/views.view.reports_cards.yml
+++ b/configsync/views.view.reports_cards.yml
@@ -10,15 +10,17 @@ dependencies:
     - field.storage.node.field_requested_datetime
     - field.storage.node.field_requested_timestamp
     - field.storage.node.field_service_name
+    - field.storage.node.field_status
     - node.type.report
     - system.menu.main
     - taxonomy.vocabulary.neighborhoods
     - taxonomy.vocabulary.service
   content:
-    - 'taxonomy_term:neighborhoods:4469f261-386d-4916-bad7-21ff12784097'
+    - 'taxonomy_term:service:a1de9257-fdbf-4856-b8d6-79a990c6ac20'
   module:
     - datetime
     - node
+    - options
     - taxonomy
     - user
 _core:
@@ -449,6 +451,68 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
+        field_status:
+          id: field_status
+          table: node__field_status
+          field: field_status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: true
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: true
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: list_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
         field_media_url:
           id: field_media_url
           table: node__field_media_url
@@ -716,7 +780,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: "<div class=\"card h-100\" style=\"width: 18rem;\">\r\n  {{ field_media_url }}\r\n  <div class=\"card-body\">\r\n    <h4 class=\"card-title\">{{ title }}</h5>\r\n    <span class=\"badge badge-secondary\">{{ field_neighborhood }}</span>\r\n    <p class=\"card-text\">{{ field_description }}</p>\r\n  </div>\r\n  <ul class=\"list-group list-group-flush\">\r\n    <li class=\"list-group-item\">{{ field_requested_timestamp }}</li>\r\n  </ul>\r\n  <div class=\"card-footer text-muted\">\r\n    <a href=\"/node/{{ nid }}\" class=\"btn btn-primary stretched-link\">More details</a>\r\n  </div>\r\n</div>"
+            text: "<div class=\"card h-100\" style=\"width: 18rem;\">\r\n  {{ field_media_url }}\r\n  <div class=\"card-body\">\r\n    <h4 class=\"card-title\">{{ title }}</h5>\r\n    <span class=\"badge badge-secondary\">{{ field_status }}</span>\r\n    <span class=\"badge badge-secondary\">{{ field_neighborhood }}</span>\r\n    <p class=\"card-text\">{{ field_description }}</p>\r\n  </div>\r\n  <ul class=\"list-group list-group-flush\">\r\n    <li class=\"list-group-item\">{{ field_requested_timestamp }}</li>\r\n  </ul>\r\n  <div class=\"card-footer text-muted\">\r\n    <a href=\"/node/{{ nid }}\" class=\"btn btn-primary stretched-link\">More details</a>\r\n  </div>\r\n</div>"
             make_link: false
             path: ''
             absolute: false
@@ -1143,6 +1207,47 @@ display:
                 operator: 'not empty'
                 value: ''
           plugin_id: string
+        field_status_value:
+          id: field_status_value
+          table: node__field_status
+          field: field_status_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_status_value_op
+            label: Status
+            description: ''
+            use_operator: false
+            operator: field_status_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_status_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          plugin_id: list_field
         field_requested_datetime_value:
           id: field_requested_datetime_value
           table: node__field_requested_datetime
@@ -1272,6 +1377,7 @@ display:
         - 'config:field.storage.node.field_requested_datetime'
         - 'config:field.storage.node.field_requested_timestamp'
         - 'config:field.storage.node.field_service_name'
+        - 'config:field.storage.node.field_status'
   page:
     display_options:
       path: reports
@@ -1318,6 +1424,7 @@ display:
         - 'config:field.storage.node.field_requested_datetime'
         - 'config:field.storage.node.field_requested_timestamp'
         - 'config:field.storage.node.field_service_name'
+        - 'config:field.storage.node.field_status'
   page_1:
     display_plugin: page
     id: page_1
@@ -1431,3 +1538,4 @@ display:
         - 'config:field.storage.node.field_requested_datetime'
         - 'config:field.storage.node.field_requested_timestamp'
         - 'config:field.storage.node.field_service_name'
+        - 'config:field.storage.node.field_status'

--- a/docroot/modules/custom/bos311/src/FetchResponses.php
+++ b/docroot/modules/custom/bos311/src/FetchResponses.php
@@ -3,8 +3,6 @@
 namespace Drupal\bos311;
 
 use Drupal\node\Entity\Node;
-use Drupal\Core\Link;
-use Drupal\Core\Url;
 
 class FetchResponses
 {

--- a/docroot/modules/custom/bos311/src/Record.php
+++ b/docroot/modules/custom/bos311/src/Record.php
@@ -288,11 +288,11 @@ class Record
         return $date;
     }
 
-    private function formatIso8601($timestamp) {
+    public static function formatIso8601($timestamp) {
         return date('Y-m-d\TH:i:s', ($timestamp + 14400));
     }
 
-    private function cleanChars($string) {
+    public static function cleanChars($string) {
         $cleanString = preg_replace('/[\x00-\x1F\x7F-\xFF]/', '', $string);
         return $cleanString;
     }

--- a/docroot/modules/custom/bos311/src/Response.php
+++ b/docroot/modules/custom/bos311/src/Response.php
@@ -21,6 +21,7 @@ class Response {
     catch (ServerException $e) {
       if ($retryOnError) {
         $retryOnError--;
+          usleep(500000);
         return self::fetch($url, $retryOnError);
       }
       echo 'Caught response: ' . $e->getResponse()->getStatusCode();

--- a/docroot/modules/custom/bos311/src/Response.php
+++ b/docroot/modules/custom/bos311/src/Response.php
@@ -21,7 +21,7 @@ class Response {
     catch (ServerException $e) {
       if ($retryOnError) {
         $retryOnError--;
-          usleep(500000);
+          usleep(250000);
         return self::fetch($url, $retryOnError);
       }
       echo 'Caught response: ' . $e->getResponse()->getStatusCode();

--- a/docroot/modules/custom/bos311/src/UpdateRecord.php
+++ b/docroot/modules/custom/bos311/src/UpdateRecord.php
@@ -1,0 +1,43 @@
+<?php
+
+
+namespace Drupal\bos311;
+
+use Drupal\node\Entity\Node;
+
+class UpdateRecord
+{
+    private Node $existingReport;
+    private string $status_notes;
+    private $updated_datetime;
+    private string $status;
+
+    public function __construct(Node $existingReport, $status_notes, $updated_datetime, $status)
+    {
+        $this->existingReport = $existingReport;
+        $this->status_notes = $status_notes;
+        $this->updated_datetime = Record::formatDateTime($updated_datetime);
+        $this->status = $status;
+    }
+
+    /**
+     * Given an existing report, only update the fields that are likely to change.
+     * @param Node $existingReport
+     * @return mixed
+     */
+    public function updateReportData() {
+        $this->existingReport->field_status_notes = Record::cleanChars($this->status_notes);
+        $this->existingReport->set('field_updated_timestamp', $this->updated_datetime);
+        $this->existingReport->set('field_updated_datetime', Record::formatIso8601($this->updated_datetime));
+        $this->existingReport->field_status = $this->status;
+
+        return $this->existingReport;
+    }
+
+    public function saveUpdatedExistingReport()
+    {
+        $this->existingReport->save();
+        return $this->existingReport;
+    }
+
+}

--- a/docroot/themes/custom/bos311bootstrap/templates/node--report--full.html.twig
+++ b/docroot/themes/custom/bos311bootstrap/templates/node--report--full.html.twig
@@ -87,8 +87,16 @@
       <ul class="list-group list-group-flush">
         <li class="list-group-item"><h4>{{ content.field_service_name }}</h4></li>
         <li class="list-group-item">{{ content.field_neighborhood.0 }} / {{ content.field_zip_code.0 }}</li>
-        <li class="list-group-item"><h6>Opened on:</h6> {{ content.field_requested_datetime }}</li>
-        <li class="list-group-item">{{ content.field_description }}</li>
+        <li class="list-group-item">
+          <h6>Opened on:</h6> <em>{{ content.field_requested_datetime }}</em>
+          <p>{{ content.field_description }}</p>
+        </li>
+        {% if content.field_status_notes|render %}
+          <li class="list-group-item">
+            <h6>Closed on:</h6> <em>{{ content.field_updated_datetime }}</em>
+            <p>{{ content.field_status_notes }}</p>
+          </li>
+        {% endif %}
         <li class="list-group-item">{{ content.field_address }}</li>
         <li class="list-group-item">
           <iframe height="350" width="100%" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://www.openlinkmap.org/small.php?lat={{ content.field_latitude.0 }}&lon={{ content.field_longitude.0 }}&zoom=17"></iframe>


### PR DESCRIPTION
On every cron run, load a random set of open reports and check to see if they are now closed.

**This PR:**
1. Loads 250 open reports from the last two weeks
1. Loads an additional 250 open reports from the last six months
1. Checks to see if the status of each one has been changed from open to closed by pulling the report from the API
1. If so, updates the status notes, status, and updated datetime fields and resaves the node.

In addition
1. Request detail pages now conditionally show closed date and closed status notes for closed reports
1. List pages show an "open" or "closed" badge on cards
1. You can now filter on status when searching

**Problems:**
1. ~~Many reports may sit open forever. If the percentage that does is above `n`, this might be _extremely_ inefficient.~~
1. ~~Most people are mostly interested in recent reports. This system should give preference to recent reports (but not _too_ recent, as those are unlikely to have been updated/closed yet)~~

**Suggestions:**
* ~~Load 500 random open reports from the last 6 months (instead of all time). Those are more likely to have been updated (Reports that have sat open for years are less likely to be closed.~~